### PR TITLE
feat(migration): adds db migrations into the storage module

### DIFF
--- a/@mzm/config/deno.json
+++ b/@mzm/config/deno.json
@@ -4,9 +4,11 @@
   "exports": "./mod.ts",
   "license": "MIT",
   "imports": {
+    "@marianmeres/migrate": "jsr:@marianmeres/migrate@^1.0.2",
     "@std/assert": "jsr:@std/assert@^1.0.15",
     "@std/fs": "jsr:@std/fs@^1.0.19",
     "@std/path": "jsr:@std/path@^1.1.2",
+    "@std/semver": "jsr:@std/semver@^1.0.6",
     "@std/testing": "jsr:@std/testing@^1.0.16"
   }
 }

--- a/@mzm/config/migration/1.0.0/mod.ts
+++ b/@mzm/config/migration/1.0.0/mod.ts
@@ -1,0 +1,24 @@
+// deno-coverage-ignore-file
+import {debuglog} from 'node:util'
+const log = debuglog('config:migrate')
+
+export async function up(context: any) {
+  const store = context.store
+
+  log('setting inital value for core.api-host')
+  await store.set('core.host.api', 'https://api.mezmo.com')
+
+  log('setting inital value for core.stream-host')
+  await store.set('core.host.stream', 'https://tail.mezmo.com')
+
+  log('setting initial value for core.log.level')
+  await store.set('core.log.level', 'ERROR')
+
+  log('setting initial value for search.page.ttl')
+  await store.set('search.page.ttl', 1000 * 60)
+
+  log('setting inital value for search.page.limit')
+  await store.set('search.page.limit', 100)
+}
+
+export async function down() {}

--- a/@mzm/config/migration/2.0.0/mod.ts
+++ b/@mzm/config/migration/2.0.0/mod.ts
@@ -1,0 +1,36 @@
+// deno-coverage-ignore-file
+import {DatabaseSync} from 'node:sqlite'
+
+export async function up(context: any) {
+  const db: DatabaseSync = context.db as DatabaseSync
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS conversation(
+      conversation_session_id TEXT PRIMARY KEY
+    , created_at INTEGER NOT NULL DEFAULT (unixepoch())
+    , active BOOLEAN NOT NULL DEFAULT FALSE
+    );
+    CREATE TABLE IF NOT EXISTS conversation_history(
+      created_at INTEGER NOT NULL DEFAULT (unixepoch())
+    , conversation_history_id TEXT PRIMARY KEY DEFAULT (LOWER(HEX(RANDOMBLOB(8))))
+    , role TEXT NOT NULL
+    , content TEXT NOT NULL
+    , conversation_session_id TEXT NOT NULL
+    , first_message BOOLEAN DEFAULT FALSE
+    , FOREIGN KEY (conversation_session_id)
+      REFERENCES conversation(conversation_session_id)
+      ON DELETE CASCADE
+    );
+
+    CREATE UNIQUE INDEX conversation_active_uniq ON conversation(active) WHERE active = 1;
+    CREATE INDEX conversation_history_session_id_idx ON conversation_history(conversation_session_id);
+    CREATE INDEX conversation_session_id_idx ON conversation(conversation_session_id);
+  `)
+}
+
+export async function down(context: any) {
+  const db: DatabaseSync = context.db as DatabaseSync
+  db.exec(`
+    DROP TABLE IF EXISTS conversation_history;
+    DROP TABLE IF EXISTS conversation;
+  `)
+}

--- a/@mzm/config/migration/mod.ts
+++ b/@mzm/config/migration/mod.ts
@@ -1,0 +1,3 @@
+
+export * as '1.0.0' from './1.0.0/mod.ts'
+export * as '2.0.0' from './2.0.0/mod.ts'

--- a/@mzm/core/lang/lang.test.ts
+++ b/@mzm/core/lang/lang.test.ts
@@ -1,0 +1,117 @@
+import {assertEquals} from '@std/assert'
+import {typeOf, toArray} from './mod.ts'
+
+class FooBar {
+  get [Symbol.toStringTag]() {
+    return 'FooBar'
+  }
+}
+
+Deno.test({
+  name: 'typeOf'
+, fn: () => {
+    assertEquals(typeof typeOf, 'function', 'typeOf is a function')
+    const cases = [
+      {
+        value: ''
+      , expected: 'string'
+      }
+    , {
+        value: new Date().toISOString()
+      , expected: 'string'
+      }
+    , {
+        value: new Date()
+      , expected: 'date'
+      }
+    , {
+        value: null
+      , expected: 'null'
+      }
+    , {
+        value: undefined
+      , expected: 'undefined'
+      }
+    , {
+        value: 1.1
+      , expected: 'number'
+      }
+    , {
+        value: /\w+/
+      , expected: 'regexp'
+      }
+    , {
+        value: new RegExp('\\w+')
+      , expected: 'regexp'
+      }
+    , {
+        value: new FooBar()
+      , expected: 'foobar'
+      }
+    , {
+        value: new Set()
+      , expected: 'set'
+      }
+    , {
+        value: [1, 2]
+      , expected: 'array'
+      }
+    , {
+        value: {}
+      , expected: 'object'
+      }
+    , {
+        value: true
+      , expected: 'boolean'
+      }
+    , {
+        value: () => {}
+      , expected: 'function'
+      }
+    , {
+        value: async () => {}
+      , expected: 'asyncfunction'
+      }
+    ]
+    for (const current of cases) {
+      assertEquals(
+        typeOf(current.value)
+      , current.expected
+      )
+    }
+  }
+})
+
+Deno.test({
+  name: 'toArray'
+, fn: () => {
+
+    const cases = [
+      {value: undefined, expected: [], message: 'toArray(undefined) == []'}
+    , {value: null, expected: [], message: 'toArray(null) == []'}
+    , {value: 1, expected: [1], message: 'toArray(1) == [1]'}
+    , {value: '', expected: [], message: 'toArray(\'\') == []'}
+    , {value: 'test', expected: ['test']}
+    , {value: '1,2,3', expected: ['1', '2', '3']}
+    , {value: '1, 2, 3', expected: ['1', '2', '3']}
+    , {value: '1, 2, 3', expected: ['1', ' 2', ' 3'], sep: ','}
+    , {value: '1|2|3', expected: ['1', '2', '3'], sep: '|'}
+    , {value: [1, 2, 3], expected: [1, 2, 3]}
+    , {value: new Set([1, null, 'test']), expected: [1, null, 'test']}
+    ]
+    for (const current of cases) {
+      const args: Array<unknown> = [current.value]
+      if (current.sep) {
+        args.push(current.sep)
+      }
+
+      assertEquals(
+        // @ts-ignore the prevention of using a spread is not helpful
+        toArray(...args)
+      , current.expected
+      , current.message || `toArray(${current.value}) == ${current.expected}`
+      )
+    }
+
+  }
+})

--- a/@mzm/core/lang/string.test.ts
+++ b/@mzm/core/lang/string.test.ts
@@ -1,0 +1,103 @@
+import * as string from './string.ts'
+import {assertEquals, assertThrows} from '@std/assert'
+
+
+Deno.test({
+  name: 'string.upper'
+, fn: () => {
+    assertEquals(typeof string.upper, 'function', 'upper is a function')
+    const cases = [{
+      value: 'test'
+    , expected: 'TEST'
+    }, {
+      value: 'this Is A test'
+    , expected: 'THIS IS A TEST'
+    }, {
+      value: null
+    , expected: ''
+    }, {
+      value: undefined
+    , expected: ''
+    }, {
+      value: {}
+    , expected: '[OBJECT OBJECT]'
+    }]
+
+    for (const current of cases) {
+      assertEquals(
+        string.upper(current.value)
+      , current.expected
+      , `upper(${current.value}) == ${current.expected}`
+      )
+    }
+
+    assertThrows(() => {
+      string.upper(Object.create(null))
+    }, 'string.upper called on non-string value')
+  }
+})
+
+Deno.test({
+  name: 'string.typecast'
+, fn: () => {
+    assertEquals(typeof string.typecast, 'function', 'typecast is a function')
+    assertEquals(string.typecast({x: 1}), {x: 1}, 'non string value')
+    const cases = [{
+      value: 'foo'
+    , expected: 'foo'
+    }, {
+      value: 'true'
+    , expected: true
+    }, {
+      value: 'false'
+    , expected: false
+    }, {
+      value: true
+    , expected: true
+    }, {
+      value: false
+    , expected: false
+    }, {
+    }, {
+      value: '123'
+    , expected: 123
+    , message: 'integer value'
+    }, {
+      value: '123.45'
+    , expected: 123.45
+    , message: 'float value'
+    }, {
+      value: 'null'
+    , expected: null
+    , message: 'null string value'
+    }, {
+      value: null
+    , expected: null
+    , message: 'null literal value'
+    }, {
+      value: 'undefined'
+    , expected: undefined
+    , message: 'undefined string value'
+    }, {
+      value: undefined
+    , expected: undefined
+    , message: 'undefined literal value'
+    }, {
+      value: ''
+    , expected: ''
+    , message: 'empty string value'
+    }, {
+      value: Infinity
+    , expected: Infinity
+    , message: 'Infinity returns input'
+    }]
+
+    for (const current of cases) {
+      assertEquals(
+        string.typecast(current.value)
+      , current.expected
+      , current.message || `typecast(${current.value}) == ${current.expected}`
+      )
+    }
+  }
+})

--- a/deno.lock
+++ b/deno.lock
@@ -12,6 +12,10 @@
     "jsr:@cliffy/table@1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@cliffy/table@^1.0.0-rc.8": "1.0.0-rc.8",
     "jsr:@littletof/charmd@~0.1.2": "0.1.2",
+    "jsr:@marianmeres/item-collection@^1.2.11": "1.2.19",
+    "jsr:@marianmeres/migrate@^1.0.2": "1.0.2",
+    "jsr:@marianmeres/pubsub@^2.1.1": "2.2.0",
+    "jsr:@marianmeres/searchable@^2.2.1": "2.2.1",
     "jsr:@std/assert@1": "1.0.15",
     "jsr:@std/assert@^1.0.15": "1.0.15",
     "jsr:@std/assert@~1.0.6": "1.0.15",
@@ -33,6 +37,7 @@
     "jsr:@std/path@^1.1.2": "1.1.2",
     "jsr:@std/path@~1.0.6": "1.0.9",
     "jsr:@std/regexp@^1.0.1": "1.0.1",
+    "jsr:@std/semver@^1.0.6": "1.0.6",
     "jsr:@std/testing@^1.0.16": "1.0.16",
     "jsr:@std/text@^1.0.16": "1.0.16",
     "jsr:@std/text@~1.0.7": "1.0.16",
@@ -99,6 +104,25 @@
         "jsr:@std/fmt@0.223.0"
       ]
     },
+    "@marianmeres/item-collection@1.2.19": {
+      "integrity": "0fd594a1c5c7c6410ba0ed21910a426ecf83577a90d50fb50ccea4de52e78184",
+      "dependencies": [
+        "jsr:@marianmeres/pubsub",
+        "jsr:@marianmeres/searchable"
+      ]
+    },
+    "@marianmeres/migrate@1.0.2": {
+      "integrity": "635e0bca4e2ecfccad9637194df2ece2fc6fcc6af46e7ba3b2844a21d89a5782",
+      "dependencies": [
+        "jsr:@marianmeres/item-collection"
+      ]
+    },
+    "@marianmeres/pubsub@2.2.0": {
+      "integrity": "7edf68b6ea2aac8cbfb1c253c60a21917e2d296c6ec21c88a40b5a03d70875ad"
+    },
+    "@marianmeres/searchable@2.2.1": {
+      "integrity": "05348848d300a891e06e730f7bba103fa10f29588323f28893d8c3f18f1efc17"
+    },
     "@std/assert@1.0.15": {
       "integrity": "d64018e951dbdfab9777335ecdb000c0b4e3df036984083be219ce5941e4703b",
       "dependencies": [
@@ -152,6 +176,9 @@
     },
     "@std/regexp@1.0.1": {
       "integrity": "5179d823465085c5480dafb44438466e83c424fadc61ba31f744050ecc0f596d"
+    },
+    "@std/semver@1.0.6": {
+      "integrity": "b7c98ae2843547cf3f7ac37f3995889e6e4cee0a97b57b57f17f62722843303c"
     },
     "@std/testing@1.0.16": {
       "integrity": "a917ffdeb5924c9be436dc78bc32e511760e14d3a96e49c607fc5ecca86d0092",
@@ -247,9 +274,11 @@
       },
       "@mzm/config": {
         "dependencies": [
+          "jsr:@marianmeres/migrate@^1.0.2",
           "jsr:@std/assert@^1.0.15",
           "jsr:@std/fs@^1.0.19",
           "jsr:@std/path@^1.1.2",
+          "jsr:@std/semver@^1.0.6",
           "jsr:@std/testing@^1.0.16"
         ]
       },


### PR DESCRIPTION
uses a generic migration package and wires it up to the sqlite db. Migration tracking is handled by the user_version pragma of sqlite

See: https://sqlite.org/pragma.html#pragma_user_version