### PR TITLE
feat(command-get): adds account sub command for introspecting accounts

### DIFF
--- a/@mzm/command-get/account/mod.ts
+++ b/@mzm/command-get/account/mod.ts
@@ -1,0 +1,41 @@
+// @ts-nocheck ignore until command sub class types are figured out
+
+import {EOL} from 'node:os'
+import {toArray} from '@mzm/core/lang'
+import {ResourceCommand} from '@mzm/core'
+import {type Account, default as resource} from '@mzm/core/resource'
+
+function renderSuspend(value: boolean | undefined): string {
+  return value === true ? '*' : ''
+}
+export default new ResourceCommand('account')
+  .description([
+    'The account subcommand of GET allows you to view all of the accounts that you'
+  , 'have immdiate access to. When access keys issued to a service account, the list'
+  , 'of accounts will only include the single account the service account is bound to'
+  ].join(EOL))
+  .apiVersion('v3')
+  .pk('account')
+  .arguments('[account-id:string]')
+  .usage('[id] [options]')
+  .column({name: 'NAME', property: 'company'})
+  .column({name: 'OWNER', property: 'owneremail'})
+  .column({name: 'TYPE', property: 'plan.type'})
+  .column({name: 'STATUS', property: 'status'})
+  .column({name: 'SUSPENDED', property: 'meta.suspendIngestion', render: renderSuspend})
+  .column({name: 'ID', property: 'pk'})
+  .example('see all of your accounts', 'mzm get account')
+  .example('see an individual account', 'mzm get account fad41bbce')
+  .action(async function(options: any, pk?: string) {
+    const to_render: Account | Array<Account> = pk
+    ? await resource.v3.account.get(pk)
+    : await resource.v3.account.list()
+
+    if (options.quiet) return console.log(
+      toArray(to_render).map((item) => {
+        return item.pk
+      }).join(' ')
+    )
+
+    console.log(this.render(to_render, options.output))
+  })

--- a/@mzm/command-get/mod.ts
+++ b/@mzm/command-get/mod.ts
@@ -1,7 +1,8 @@
 import {EOL} from 'node:os'
 import {MZMCommand} from '@mzm/core'
-import {default as ViewCommand} from './view/mod.ts'
-import {default as ConversationCommand} from './conversation/mod.ts'
+import ViewCommand from './view/mod.ts'
+import ConversationCommand from './conversation/mod.ts'
+import AccountCommand from './account/mod.ts'
 
 export default new MZMCommand()
   .name('get')
@@ -20,5 +21,6 @@ export default new MZMCommand()
   .action(function () {
     this.showHelp()
   })
-  .command('view', ViewCommand)
+  .command('account', AccountCommand)
   .command('conversation', ConversationCommand)
+  .command('view', ViewCommand)

--- a/@mzm/core/resource/mod.ts
+++ b/@mzm/core/resource/mod.ts
@@ -1,10 +1,12 @@
 import {default as client} from './client.ts'
-import {default as v1} from './v1/mod.ts'
-import {default as parse} from './parse.ts'
-import {default as stringify} from './stringify.ts'
+import v1 from './v1/mod.ts'
+import v3 from './v3/mod.ts'
+import parse from './parse.ts'
+import stringify from './stringify.ts'
 import {ChatRole} from './v1/conversation/types.ts'
 export type {View} from './v1/view/types.ts'
 export type {ChatHistory, ChatResponse, ChatResponseMessage, Conversation, UserMessage} from './v1/conversation/types.ts'
 export {StringifyFormat} from './types.ts'
 export {client, parse, stringify, ChatRole}
-export default {v1}
+
+export default {v1, v3}

--- a/@mzm/core/resource/v1/view/mod.ts
+++ b/@mzm/core/resource/v1/view/mod.ts
@@ -22,7 +22,11 @@ type JoiResponse = {
 export async function get(view_id: string, params?: Record<string, string>): Promise<View | null> {
   try {
     const res = await client.get(`v1/config/view/${view_id}`, params)
-    if (res.status === 200) return res.data as View
+    if (res.status === 200) {
+      const view = res.data as View
+      view.pk = view.viewid
+      return view
+    }
   } catch (err) {
     const cast: RequestError = err as RequestError
     const status = cast?.response?.status

--- a/@mzm/core/resource/v3/account/mod.ts
+++ b/@mzm/core/resource/v3/account/mod.ts
@@ -1,0 +1,81 @@
+import type {RequestError, RequestResponse} from '@anitrend/request-client'
+import {AuthorizationError, CommunicationError, InputError, GenericError} from '../../../error.ts'
+import client from '../../client.ts'
+import {type Account} from './types.ts'
+import {type IV3ListResponse, type IV3DetailResponse} from '../types.ts'
+
+export async function list(params?: Record<string, string>): Promise<Array<Account>> {
+  try {
+    const res  = await client.get('v3/auth/account', params)
+    const body: IV3ListResponse<Account> = res.data as IV3ListResponse<Account>
+    for (const account of body.data) {
+      account.pk = account.account
+    }
+    return body.data as Array<Account>
+  } catch (err) {
+    if (err instanceof GenericError) throw err
+    const cast: RequestError = err as RequestError
+    const status = cast?.response?.status
+
+    switch (status) {
+      case 401: {
+        throw AuthorizationError.from(
+          'There was a problem authenticating the previous operation. Make sure your access key is still valid'
+        , cast?.response?.data
+        )
+      }
+      case 403: {
+        throw AuthorizationError.from(
+          'Make sure you have the appropriate permissions to read views in the appropriate account'
+        , cast?.response?.data
+        )
+      }
+      case 404: {
+        return []
+      }
+      default: {
+        throw CommunicationError.from(
+          'Try again in a few minutes. If the problem persists, please contact customer support.'
+        , cast?.response?.data
+        )
+      }
+    }
+  }
+}
+
+export async function get(pk: string, params?: Record<string, string>): Promise<Account | null> {
+  try {
+    const res  = await client.get(`v3/auth/account/${pk}`, params)
+    if (res.status === 200) {
+      const body: IV3DetailResponse<Account> = res.data as IV3DetailResponse<Account>
+      body.data.pk = body.data.account
+      return body.data as Account
+    }
+    return null
+  } catch (err) {
+    const cast: RequestError = err as RequestError
+    const status = cast?.response?.status
+    if (err instanceof GenericError) throw err
+    switch(status) {
+      case 401: {
+        throw AuthorizationError.from(
+          'There was a problem authenticating the previous operation. Make sure your access key is still valid'
+        , cast?.response?.data
+        )
+      }
+      case 403: {
+        throw AuthorizationError.from(
+          'Make sure you have the appropriate permissions to read views in the appropriate account'
+        , cast?.response?.data
+        )
+      }
+      case 404: {
+        // not really an "error"
+        return null
+      }
+      default: {
+        throw err
+      }
+    }
+  }
+}

--- a/@mzm/core/resource/v3/account/types.ts
+++ b/@mzm/core/resource/v3/account/types.ts
@@ -1,0 +1,2 @@
+
+export type Account = Record<string, any>

--- a/@mzm/core/resource/v3/mod.ts
+++ b/@mzm/core/resource/v3/mod.ts
@@ -1,0 +1,3 @@
+import * as account from './account/mod.ts'
+
+export default {account}

--- a/@mzm/core/resource/v3/types.ts
+++ b/@mzm/core/resource/v3/types.ts
@@ -1,0 +1,18 @@
+import type {RequestResponse} from '@anitrend/request-client'
+
+export interface IV3ListResponse<T> extends RequestResponse {
+  meta: {
+    pk: string | null
+  , links: Record<string, Record<string, string>>
+  , type: string
+  }
+  data: Array<T>
+}
+export interface IV3DetailResponse<T> extends RequestResponse {
+  meta: {
+    pk: string | null
+  , links: Record<string, Record<string, string>>
+  , type: string
+  }
+  data: T
+}


### PR DESCRIPTION
allows a subject to view the accounts they have direct access to. For a service account it is only the account they are bound to. For a user, it is the entire list of accounts