### PR TITLE
fix(command-log): fix windows signal handling

### DIFF
--- a/@mzm/command-log/search/command.ts
+++ b/@mzm/command-log/search/command.ts
@@ -8,6 +8,7 @@ import {client} from '@mzm/core/resource'
 import {pprint, getLogger} from '@mzm/log';
 import {storage} from '@mzm/config'
 
+const WINDOWS = Deno.build.os === 'windows'
 const log = getLogger('default')
 const debug = debuglog('core:command:log:search')
 const StartPrefernce = new EnumType(['head', 'tail'])
@@ -130,11 +131,15 @@ const search = new MZMCommand()
 
     const controller = new AbortController()
 
-    Deno.addSignalListener('SIGTERM', () => {
+    if (!WINDOWS) Deno.addSignalListener('SIGTERM', () => {
       controller.abort()
     })
 
     Deno.addSignalListener('SIGINT', () => {
+      controller.abort()
+    })
+
+    Deno.addSignalListener('SIGHUP', () => {
       controller.abort()
     })
 


### PR DESCRIPTION
The log command would add an os signal handler for SIGINT and SIGTERM, but windows doesn't support SIGTERM, and deno will throw and error. This updates the logs commands to only and sigterm on non-widows platforms, and additionally adds a handler for SIGHUP which windows does have support for

Fixes: #28