### PR TITLE
fix(core): make sure version object can be translated to a string

### DIFF
--- a/@mzm/core/update/providers/github.ts
+++ b/@mzm/core/update/providers/github.ts
@@ -274,7 +274,13 @@ export default class GithubReleaseProvider extends Provider {
         return true
       })
       .map((value) => {
-        return {created_at: value.created_at, tag: value.tag_name}
+        return {
+          created_at: value.created_at
+        , tag: value.tag_name
+        , toString(): string {
+            return value.tag_name.replace('v', '')
+          }
+        }
       })
       .sort(sortVersions)
 


### PR DESCRIPTION
When the verbose flag was used with the upgrade command it would print [object Object] as we're constructing release objects rather than the string values the parent command expects. There isn't much of a way to insert our logic in to the parent as its a being managed by a single function rather than a class instance that can be overridden.

This update gives our release object a toString function so that if it is being formatted like it were a string, it can be translated as such.

<img width="704" height="89" alt="image" src="https://github.com/user-attachments/assets/8c0e3705-80bb-4000-ad1c-ab3fd6ee2086" />

Fixes: #32