### PR TITLE
fix(upgrade): correctly handle removal of running program on windows

### DIFF
--- a/@mzm/core/error.ts
+++ b/@mzm/core/error.ts
@@ -384,3 +384,17 @@ export class ClientError extends GenericError {
     )
   }
 }
+
+export class NotFoundError extends GenericError {
+  static override error_code: string = 'ENOENT'
+  static override exit_code: number = 6
+  override error_code: string = 'ENOENT'
+  override exit_code: number = 6
+  static override from(help: string, reason?: any) {
+    return super.from(
+      'Not Found'
+    , help
+    , reason
+    )
+  }
+}


### PR DESCRIPTION
Unlike unix based systems, on windows based systems you cannot remove a file if it is still runining. This would cause the upgrade command to fail when it would try to replace the command in place. The recommendation on windows platforms is to rename the file, and use another process to remove that file at a later time.

This update ths upgrade command to rename the running binary and store the location of that file. The next time the program runs it will attempt to remove that file.

Fixes: #36